### PR TITLE
Fix xss in group name and description

### DIFF
--- a/app/admin/pageViewGroups.php
+++ b/app/admin/pageViewGroups.php
@@ -74,14 +74,14 @@
 				$groupMembersCount = sqlValue("select count(1) from membership_users where groupID='$row[0]'");
 				?>
 				<tr>
-					<td><a href="pageEditGroup.php?groupID=<?php echo $row[0]; ?>"><?php echo $row[1]; ?></a></td>
-					<td><?php echo thisOr($row[2]); ?></td>
+					<td><a href="pageEditGroup.php?groupID=<?php echo $row[0]; ?>"><?php echo htmlspecialchars($row[1]); ?></a></td>
+					<td><?php echo htmlspecialchars(thisOr($row[2])); ?></td>
 					<td class="text-right"><?php echo $groupMembersCount; ?></td>
 					<td class="text-center">
 						<a href="pageEditGroup.php?groupID=<?php echo $row[0]; ?>" title="<?php echo $Translation['Edit group']; ?>"><i class="glyphicon glyphicon-pencil"></i></a>
 						<?php if(!$groupMembersCount) { ?>
-								<a href="pageDeleteGroup.php?groupID=<?php echo $row[0]; ?>" 
-								   title="<?php echo $Translation['delete group'] ; ?>" 
+								<a href="pageDeleteGroup.php?groupID=<?php echo $row[0]; ?>"
+								   title="<?php echo $Translation['delete group'] ; ?>"
 								   onClick="return confirm('<?php echo addslashes($Translation['confirm delete group']); ?>');">
 									<i class="glyphicon glyphicon-trash text-danger"></i>
 								</a>
@@ -112,7 +112,7 @@
 							<a class="btn btn-default" href="pageViewGroups.php?searchGroups=<?php echo $searchHTML; ?>&page=<?php echo ($page > 1 ? $page - 1 : 1); ?>"><?php echo $Translation['previous']; ?></a>
 						</th>
 						<th class="text-center" width="33%">
-							<?php 
+							<?php
 								$originalValues =  array ('<GROUPNUM1>','<GROUPNUM2>','<GROUPS>' );
 								$replaceValues = array ( $start+1 , $start+db_num_rows($res) , $numGroups );
 								echo str_replace ( $originalValues , $replaceValues , $Translation['displaying groups'] );


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/bounties/1-other-online-invoicing-system

### ⚙️ Description *

Cross-Site Scripting (XSS) attacks are a type of injection, in which malicious scripts are injected into otherwise benign and trusted websites. XSS attacks occur when an attacker uses a web application to send malicious code, generally in the form of a browser side script, to a different end user. Flaws that allow these attacks to succeed are quite widespread and occur anywhere a web application uses input from a user within the output it generates without validating or encoding it.

### 💻 Technical Description *

Cross-Site Scripting (XSS) attacks are mitigated by sanitizing the user inputs before rendering, thereby preventing malicious execution.

### 🐛 Proof of Concept (PoC) *

1. Go to https://bigprof.com/appgini/applications/online-invoicing-system
2. click on Launch private demo on Gitpod https://gitpod.io/#https://github.com/bigprof-software/online-invoicing-system
3. login using appgini in all the fields and click on 3rd option "go to admin homepage...."
4. select total groups and click on edit button for anonymous
5. Edit the description with aaaaa"<ScRiPt>alert('XSS')</ScRiPt> and save
6. XSS will be triggered. And when u visit the grops.


### 🔥 Proof of Fix (PoF) *

Before:
<img width="1239" alt="Screenshot 2021-02-18 at 12 43 47" src="https://user-images.githubusercontent.com/3634654/108352791-a4ba7800-71e7-11eb-800e-827c1470db93.png">
<img width="659" alt="Screenshot 2021-02-18 at 12 44 05" src="https://user-images.githubusercontent.com/3634654/108352803-a71cd200-71e7-11eb-99ef-4853dd79aafc.png">
After:
<img width="788" alt="Screenshot 2021-02-18 at 12 44 20" src="https://user-images.githubusercontent.com/3634654/108352818-adab4980-71e7-11eb-974e-0775228a2a46.png">
<img width="968" alt="Screenshot 2021-02-18 at 12 44 24" src="https://user-images.githubusercontent.com/3634654/108352824-b00da380-71e7-11eb-9af7-23eed23a1a28.png">


### 👍 User Acceptance Testing (UAT)

I opened the page and I didn't get the popups anymore. It is fixed in the same way as it is implemented for users

### 🔗 Relates to...


